### PR TITLE
Allow to configure actinia host

### DIFF
--- a/charts/openeo-grassgis-driver/Chart.yaml
+++ b/charts/openeo-grassgis-driver/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.2
+version: 0.2.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 1.0.3
+appVersion: 2.0.2

--- a/charts/openeo-grassgis-driver/templates/configmap.yaml
+++ b/charts/openeo-grassgis-driver/templates/configmap.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "openeo-grassgis-driver.fullname" . }}
+  labels:
+{{ include "openeo-grassgis-driver.labels" . | indent 4 }}
+data:
+  config: |
+    [ACTINIA]
+    {{- if .Values.config.actinia_host }}
+    HOST = {{ .Values.config.actinia_host }}
+    {{- end }}
+    {{- if .Values.config.actinia_user }}
+    USER = {{ .Values.config.actinia_user }}
+    {{- end }}
+    {{- if .Values.config.actinia_password }}
+    PASSWORD = {{ .Values.config.actinia_password }}
+    {{- end }}

--- a/charts/openeo-grassgis-driver/templates/deployment.yaml
+++ b/charts/openeo-grassgis-driver/templates/deployment.yaml
@@ -35,12 +35,32 @@ spec:
             httpGet:
               path: /
               port: http
+            initialDelaySeconds: 120
+            timeoutSeconds: 120
           readinessProbe:
             httpGet:
               path: /
               port: http
+            initialDelaySeconds: 120
+            timeoutSeconds: 120
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          command: ["gunicorn", "-b", "0.0.0.0:5000", "-t", "60", "openeo_grass_gis_driver.main:flask_app"]
+          # args: ['/src/start/start.sh']
+          volumeMounts:
+            - name: config
+              mountPath: /etc/default/openeo-grassgis-driver
+          env:
+            - name: DEFAULT_CONFIG_PATH
+              value: /etc/default/openeo-grassgis-driver
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "openeo-grassgis-driver.fullname" . }}
+            items:
+              - key: config
+                path: config.ini
+
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/openeo-grassgis-driver/values.yaml
+++ b/charts/openeo-grassgis-driver/values.yaml
@@ -8,6 +8,13 @@ image:
   repository: mundialis/openeo-grassgis-driver
   pullPolicy: IfNotPresent
 
+config:
+  # allows to overwrite actinia connection parameters
+  # if they differ from default config
+  actinia_host: https://actinia-dev.mundialis.de
+  # actinia_user: example_user
+  # actinia_password: example_password
+
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
From [openeo-grassgis-driver 2.0.2](https://github.com/Open-EO/openeo-grassgis-driver/releases/tag/2.0.2) it is possible to configure the actinia instance to which the openeo-grassgis-driver should talk to. This PR allows this config to be set in the helm chart.

As the backend initally collects all actinia processes, liveness + readiness probes needed to be updated.