### PR TITLE
Fix actinia plugin name

### DIFF
--- a/charts/actinia/Chart.yaml
+++ b/charts/actinia/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.0.0
+version: 1.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/actinia/templates/configmap.yaml
+++ b/charts/actinia/templates/configmap.yaml
@@ -56,7 +56,7 @@ data:
     grass_addon_path = /root/.grass7/addons/
 
     [API]
-    plugins = ["actinia_gdi"]
+    plugins = ["actinia_module_plugin"]
     force_https_urls = True
 
     [REDIS]


### PR DESCRIPTION
As for recent actinia versions, actinia-gdi was renamed to actinia-module-plguin