### PR TITLE
Make actinia version configurable for oggd

### DIFF
--- a/charts/openeo-grassgis-driver/Chart.yaml
+++ b/charts/openeo-grassgis-driver/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.16
+version: 0.2.17
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/openeo-grassgis-driver/helmdocs.md
+++ b/charts/openeo-grassgis-driver/helmdocs.md
@@ -14,6 +14,7 @@ Current chart version is `0.2.17`
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
 | config.actinia_host | string | `"https://actinia-dev.mundialis.de"` |  |
+| config.actinia_version | string | `"v3"` |  |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"mundialis/openeo-grassgis-driver"` |  |

--- a/charts/openeo-grassgis-driver/helmdocs.md
+++ b/charts/openeo-grassgis-driver/helmdocs.md
@@ -2,7 +2,7 @@ openeo-grassgis-driver
 ======================
 A Helm chart for openeo-grassgis-driver
 
-Current chart version is `0.2.16`
+Current chart version is `0.2.17`
 
 
 

--- a/charts/openeo-grassgis-driver/templates/configmap.yaml
+++ b/charts/openeo-grassgis-driver/templates/configmap.yaml
@@ -19,3 +19,6 @@ data:
     {{- if .Values.config.actinia_locations }}
     LOCATIONS = {{ .Values.config.actinia_locations }}
     {{- end }}
+    {{- if .Values.config.actinia_version }}
+    VERSION = {{ .Values.config.actinia_version }}
+    {{- end }}

--- a/charts/openeo-grassgis-driver/values.yaml
+++ b/charts/openeo-grassgis-driver/values.yaml
@@ -11,6 +11,7 @@ image:
 config:
   # allows to overwrite actinia connection parameters
   # if they differ from default config
+  actinia_version: v3
   actinia_host: https://actinia-dev.mundialis.de
   # actinia_user: example_user
   # actinia_password: example_password


### PR DESCRIPTION
The actinia API version can be configured in the openeo-grass-gis-driver. This PR exploits this config to make it configurable via helm values as well.