### PR TITLE
Change actinia image

### DIFF
--- a/charts/actinia/Chart.yaml
+++ b/charts/actinia/Chart.yaml
@@ -14,11 +14,11 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.1.11
+version: 1.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 3.0.1.79
+appVersion: 1.0.0
 
 dependencies:
 - name: redis

--- a/charts/actinia/helmdocs.md
+++ b/charts/actinia/helmdocs.md
@@ -2,7 +2,7 @@ actinia
 =======
 A Helm chart for actinia
 
-Current chart version is `1.1.11`
+Current chart version is `1.2.0`
 
 
 
@@ -25,7 +25,7 @@ Current chart version is `1.1.11`
 | config.redis | object | `{}` |  |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"mundialis/actinia-core"` |  |
+| image.repository | string | `"mundialis/actinia"` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |
 | ingress.enabled | bool | `false` |  |

--- a/charts/actinia/values.yaml
+++ b/charts/actinia/values.yaml
@@ -5,7 +5,7 @@
 replicaCount: 1
 
 image:
-  repository: mundialis/actinia-core
+  repository: mundialis/actinia
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
As docker build was partly moved from Dockerimage `mundialis/actinia-core` to `mundialis/actinia`, this is adjusted with this PR.